### PR TITLE
chore: bump left over node 20 to 24

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
           cache-dependency-path: docs/package-lock.json
 

--- a/src/ci-github.ts
+++ b/src/ci-github.ts
@@ -248,7 +248,7 @@ function synthReusableAction(buildConfig: BuildWorkflowConfig): GithubWorkflowFi
       name: 'Set up node',
       uses: 'actions/setup-node@v4',
       with: {
-        'node-version': 20,
+        'node-version': 24,
         'cache': 'npm',
       },
     },
@@ -264,7 +264,7 @@ function synthReusableAction(buildConfig: BuildWorkflowConfig): GithubWorkflowFi
         name: 'Set up node',
         uses: 'actions/setup-node@v4',
         with: {
-          'node-version': 20,
+          'node-version': 24,
           'cache': 'pnpm',
         },
       },

--- a/test/__snapshots__/ci-github.test.ts.snap
+++ b/test/__snapshots__/ci-github.test.ts.snap
@@ -32,7 +32,7 @@ exports[`CDK Express Pipeline CI Configuration snapshot all workflows for config
             "uses": "actions/setup-node@v4",
             "with": {
               "cache": "npm",
-              "node-version": 20,
+              "node-version": 24,
             },
           },
           {
@@ -892,7 +892,7 @@ exports[`CDK Express Pipeline CI Configuration snapshot synth and deploy reusabl
             "uses": "actions/setup-node@v4",
             "with": {
               "cache": "pnpm",
-              "node-version": 20,
+              "node-version": 24,
             },
           },
           {
@@ -957,7 +957,7 @@ exports[`JsonPatch and GithubWorkflow.patch() snapshot workflows with workingDir
               "uses": "actions/setup-node@v4",
               "with": {
                 "cache": "npm",
-                "node-version": 20,
+                "node-version": 24,
               },
             },
             {


### PR DESCRIPTION
## Summary
- Replace the remaining `node 20` references with `node 24` to align with the rest of the project (`.projenrc.ts` already sets `workflowNodeVersion: '24'`, and the other workflows use 24).
- Update the generated CI workflow presets in `src/ci-github.ts` (both `preset-npm` and `preset-pnpm`).
- Update the hand-maintained docs deploy workflow `.github/workflows/deploy-docs.yml`.
- Regenerate `test/__snapshots__/ci-github.test.ts.snap` to reflect the new value.

## Test plan
- [x] `npx jest test/ci-github.test.ts` passes with the updated snapshot.
- [ ] CI green on the PR.